### PR TITLE
Undo failed triplicate action fix attempt

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,15 +1,9 @@
 name: Upload Python Package
 
 on:
-  # Run automatically *once* when a release us published
   release:
     branches: [ main ]
   workflow_dispatch:
-
-# Prevent duplicate runs for the same ref
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
 
 jobs:
   deploy:


### PR DESCRIPTION
Proposed fix didn't work. Would rather deal with one successful publish action and 2 failure notifications than all of them failing.