### PR TITLE
Remove conda-forge, use pip

### DIFF
--- a/docs/source/rtd_env.yml
+++ b/docs/source/rtd_env.yml
@@ -4,8 +4,7 @@ version: 2
 sphinx:
   configuration: docs/source/conf.py
 channels:
-  - default
-  - conda-forge
+  - defaults
 dependencies:
   - python=3.12
   - pip
@@ -13,11 +12,11 @@ dependencies:
   - ipykernel
   - sphinx
   - numpydoc>=1.1.0
-  - nbsphinx
   - ipython
   - sphinx-rtd-theme>=1.0.0
-  - jupyter-sphinx
-  - sphinx-copybutton
   - pip:
     - git+https://github.com/kurtlindberg/leafwaxtools.git@main
     - readthedocs-sphinx-search>=0.3.2
+    - jupyter-sphinx
+    - nbsphinx
+    - sphinx-copybutton


### PR DESCRIPTION
Getting readthedocs build errors due to excessive memory consumption. Try removing conda-forge channel and pip install packages missing from defaults.