### PR TITLE
Try pylipd rtd_env.yml format

### DIFF
--- a/docs/source/rtd_env.yml
+++ b/docs/source/rtd_env.yml
@@ -1,23 +1,24 @@
 # This environment includes all the required packages for this repo including running the test suite.
 name: leafwax_rtd
-version: 2
-sphinx:
-  configuration: docs/source/conf.py
 channels:
   - conda-forge
   - defaults
 dependencies:
-  - python=3.12.*
+  - python=3.12
+  - numpy
+  - pandas
+  - Sphinx
   - pip
-  - ipykernel
   - pip:
     - sphinx
+    - pylint
     - pytest
     - numpydoc>=1.1.0
     - nbsphinx
-    - ipython
-    - readthedocs-sphinx-search>=0.3.2
+    - IPython
+    - readthedocs-sphinx-search>=0.1.0
     - sphinx-rtd-theme>=1.0.0
     - jupyter-sphinx
     - sphinx-copybutton
+    - sphinx-design
     - git+https://github.com/kurtlindberg/leafwaxtools.git@main


### PR DESCRIPTION
From https://github.com/LinkedEarth/pylipd/blob/main/docs/rtd_env.yml

Trying because ReadtheDocs builds are failing again due to "excessive memory consumption". Might also be a problem with the edits to utils