### PR TITLE
Revert to pylipd version tags

### DIFF
--- a/docs/source/rtd_env.yml
+++ b/docs/source/rtd_env.yml
@@ -4,16 +4,16 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - python==3.12.13
-  - pip==26.2
+  - python=3.12.*
+  - pip
   - pip:
-    - sphinx==9.1.0
-    - pytest==9.1.1
-    - numpydoc==1.10.0
-    - nbsphinx==0.9.8
-    - ipython==9.15.0
-    - readthedocs-sphinx-search==0.3.2
-    - sphinx-rtd-theme==3.1.0
-    - jupyter-sphinx==0.5.3
-    - sphinx-copybutton==0.5.2
+    - sphinx
+    - pytest
+    - numpydoc>=1.1.0
+    - nbsphinx
+    - IPython
+    - readthedocs-sphinx-search>=0.1.0
+    - sphinx-rtd-theme>=1.0.0
+    - jupyter-sphinx
+    - sphinx-copybutton
     - git+https://github.com/kurtlindberg/leafwaxtools.git@main


### PR DESCRIPTION
Was getting a build error when installing jinja2 dependency