### PR TITLE
Remove defaults channel, only conda-forge

### DIFF
--- a/docs/source/rtd_env.yml
+++ b/docs/source/rtd_env.yml
@@ -2,7 +2,7 @@
 name: leafwax_rtd
 channels:
   - conda-forge
-  - defaults
+  - nodefaults
 dependencies:
   - python=3.12.*
   - pip


### PR DESCRIPTION
Hopefully the readthedocs "build on pull request" option I added works, too