### PR TITLE
Fix class docstrings

### DIFF
--- a/leafwaxtools/api/chain.py
+++ b/leafwaxtools/api/chain.py
@@ -34,8 +34,7 @@ class Chain:
     See also
     --------
     
-    leafwaxtools.utils.validate_init.validate_data_dimensions: Checks to make 
-    sure input user data is 2-dimensional.
+    leafwaxtools.utils.validate_init.validate_data_dimensions: Checks to make sure input user data is 2-dimensional.
     
     Examples
     --------
@@ -291,8 +290,7 @@ class Chain:
         See also
         --------
         
-        leafwaxtools.utils.correlation.corr_r: Calculates the correlation 
-        r-values for both the Chain and Isotope API classes.
+        leafwaxtools.utils.correlation.corr_r: Calculates the correlation r-values for both the Chain and Isotope API classes.
 
         """
 
@@ -323,8 +321,7 @@ class Chain:
         See also
         --------
         
-        leafwaxtools.utils.correlation.corr_p: Calculates the correlation 
-        p-values for both the Chain and Isotope API classes.
+        leafwaxtools.utils.correlation.corr_p: Calculates the correlation p-values for both the Chain and Isotope API classes.
 
         """
         

--- a/leafwaxtools/api/isotope.py
+++ b/leafwaxtools/api/isotope.py
@@ -29,8 +29,7 @@ class Isotope:
     See also
     --------
     
-    leafwaxtools.utils.validate_init.validate_data_dimensions: Checks to make 
-    sure input user data is 2-dimensional.
+    leafwaxtools.utils.validate_init.validate_data_dimensions: Checks to make sure input user data is 2-dimensional.
     
     Examples
     --------
@@ -245,8 +244,7 @@ class Isotope:
         See also
         --------
         
-        leafwaxtools.utils.correlation.corr_r: Calculates the correlation 
-        r-values for both the Chain and Isotope API classes.
+        leafwaxtools.utils.correlation.corr_r: Calculates the correlation r-values for both the Chain and Isotope API classes.
 
         """
 
@@ -277,8 +275,7 @@ class Isotope:
         See also
         --------
         
-        leafwaxtools.utils.correlation.corr_p: Calculates the correlation 
-        p-values for both the Chain and Isotope API classes.
+        leafwaxtools.utils.correlation.corr_p: Calculates the correlation p-values for both the Chain and Isotope API classes.
 
         """
 


### PR DESCRIPTION
Line wrapping in "See Also" sections of docstrings was causing a parsing error. Let's hope removing them does the trick.